### PR TITLE
Allow `null` and `undefined` root objects for input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const camelCase = (str) => str.replace(/[_.-](\w|$)/g, (_, x) => x.toUpperCase()
 
 function camelCaseRecursive(obj) {
 
-  return mapObj(obj, (key, val) => {
+  return obj == null ? obj : mapObj(obj, (key, val) => {
     const newArray = [];
 
     if (Array.isArray(val)) {

--- a/test/index.js
+++ b/test/index.js
@@ -139,3 +139,33 @@ describe('Nested keys within arrays and objects are camelCased', () => {
   });
 
 });
+
+describe('Handling null root object', () => {
+
+  it('Should not throw Error', () => {
+    var fn = function() {
+      return camelCaseKeys(null);
+    };
+    expect(fn).to.not.throw(Error);
+  });
+
+  it('Should return null', () => {
+    expect(camelCaseKeys(null)).to.be.null;
+  });
+
+});
+
+describe('Handling undefined root object', () => {
+
+  it('Should not throw Error', () => {
+    var fn = function() {
+      return camelCaseKeys(undefined);
+    };
+    expect(fn).to.not.throw(Error);
+  });
+
+  it('Should return undefined', () => {
+    expect(camelCaseKeys(undefined)).to.be.undefined;
+  });
+
+});


### PR DESCRIPTION
When I switched to using this module rather than my previously used homegrown version of this functionality, I started getting unexpected errors when an input value was `null`/`undefined`.

This change allows for those values and just returns them as-is.